### PR TITLE
Fixed Overlapping Issue on Contributors Page

### DIFF
--- a/public/css/style.css
+++ b/public/css/style.css
@@ -361,6 +361,7 @@ nav {
   padding: 0.5rem 2rem;
   background-color: var(--color-primary);
   position: relative;
+  z-index: 999;
   --color-background: white;
 }
 nav .logo {


### PR DESCRIPTION
## 📝 Description
The navbar now remains above everything

## 🔗 Related Issues
- Closes #69 

## 📸 Screenshots / 📹 Videos
![image](https://github.com/user-attachments/assets/608fe73d-c2ea-4e96-9a5d-db2d4897c99e)

## ✅ Checklist
- [x] I have read and followed the [Contributing Guidelines](https://github.com/desujoy/kushiro/blob/master/CONTRIBUTING.md).
- [x] I have tested my changes by running it, and works as expected.
- [x] I have tested these changes in at least Chrome and Firefox (other browsers if applicable).