### PR TITLE
fix: update copyright box font family and size for consistency

### DIFF
--- a/public/css/style.css
+++ b/public/css/style.css
@@ -136,10 +136,9 @@ img {
 }
 
 .copyright-box {
-  font-family: "Qwitcher Grypen", cursive;
-  font-weight: 400;
+  font-family: 'Protest Strike', sans-serif; 
   font-style: normal;
-  font-size: x-large;
+  font-size: 1.3rem; 
   left: 0;
   bottom: 0;
   width: 100%;


### PR DESCRIPTION
## 📝 Description  
This pull request addresses two issues:  
1. Updated the footer font to enhance readability.  

---

## 🔗 Related Issues  
- Closes #76

---

## 📸 Screenshots / 📹 Videos  

### **Footer Font Update:**  
**Before:**  
![Image](https://github.com/user-attachments/assets/933b8390-0bb7-4776-87fb-317ad6ec657b)  

**After:**  
![image](https://github.com/user-attachments/assets/2e9baf27-34bf-4acb-9da2-d9f999b54851)
---

## ✅ Checklist  
- [x] I have read and followed the [[Contributing Guidelines](https://github.com/desujoy/kushiro/blob/master/CONTRIBUTING.md)](https://github.com/desujoy/kushiro/blob/master/CONTRIBUTING.md).  
- [x] I have tested my changes by running them, and they work as expected.  
- [x] I have tested these changes in at least Chrome and Firefox (other browsers if applicable).  